### PR TITLE
Improved CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,13 @@
 name: CI build for every commit
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Build docker image
-      run: docker build -t yang-tools:$GITHUB_SHA .
-    - name: Run docker image
-      run: docker run --rm -e "VERSION=$GITHUB_REF_NAME" -e "NPM_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }}" yang-tools:$GITHUB_SHA
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 17
+    - run: npm ci
+    - run: npm run test:ci
+    - run: npm run build:ci


### PR DESCRIPTION
Proper package restore: `npm ci` instead of `npm install`, because `npm ci` respects package-lock.json.

No longer using docker for building, GitHub has more than adequate actions for building and testing node based projects.

Signed-off-by: Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>